### PR TITLE
fix: pin angular-schema-form to 0.8.13

### DIFF
--- a/reroils_record_editor/bundles.py
+++ b/reroils_record_editor/bundles.py
@@ -42,6 +42,7 @@ def catalog(domain):
         '{0}.po'.format(domain),
     )
 
+
 catalog_name = 'reroilsRecordEditorTranslations'
 
 i18n = GlobBundle(
@@ -62,7 +63,7 @@ schema_form_js = NpmBundle(
         'angular-sanitize': '~1.6.9',
         'tv4': '^1.3.0',
         'objectpath': '^1.2.1',
-        'angular-schema-form': '^0.8.13'
+        'angular-schema-form': '0.8.13'
     }
 )
 


### PR DESCRIPTION
To test:
1. `invenio npm`
1. `cd` to `var/instance/static`
1. `npm install`
1. `invenio assets clean`
1. `invenio assets build`
1. Load the document editor and check that you add and change the type of an author.

Submitting failed, but is fixed by https://github.com/rero/reroils-data/pull/47